### PR TITLE
fix: manual installation of modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,20 @@ except ImportError:
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 
-from owtf import __version__
 
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+#Extracts the version details 
+def get_version(init_path):
+    #Read the __init__ file
+    with open(init_path,"r+") as f:
+        init_page = f.read()
+    #Extract the version from the init file
+    for each_line in init_page.splitlines():
+        if each_line.startswith('__version__'):
+            delimiter = '"' if '"' in each_line else "'"
+            return(each_line.split(delimiter)[1])
+
 
 
 def strip_comments(l):
@@ -67,7 +78,7 @@ class PostInstallCommand(install):
 
 setup(
     name="owtf",
-    version=__version__,
+    version=get_version("owtf/__init__.py"),
     url="https://github.com/owtf/owtf",
     license="BSD",
     author="Abraham Aranguren",


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
On running setup.py, ModuleNotFoundError was being thrown.
The reason being "from owtf import __version" imports packages from install_requires dependencies which are not yet installed.


## Description
<!--- Describe your changes in detail -->
Instead of importing the version number, the code the version will now extract it from __init__.py 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owtf/owtf/issues/1057

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This ensures that the user need not manually install the dependencies and ensures the docker build process takes place without errors

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->
![Screenshot from 2020-04-24 04-06-14](https://user-images.githubusercontent.com/52630129/80157945-f5237200-85e4-11ea-96d6-887358cea9d3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
